### PR TITLE
feat(backend): 卡牌强化点数分配后端部分

### DIFF
--- a/CDBackend/demo/src/main/java/com/example/accessingdatamysql/controller/OwnCardController.java
+++ b/CDBackend/demo/src/main/java/com/example/accessingdatamysql/controller/OwnCardController.java
@@ -120,4 +120,9 @@ public class OwnCardController {
   public List<OwnCard> deleteOwnCard(@RequestParam("userId") Integer userId, @RequestParam("cardId") Integer cardId) {
     return OwnCardService.deleteOwnCard(userId, cardId);
   }
+
+  @RequestMapping(value = "/redistributeUpgrades")
+  public @ResponseBody OwnCard redistributeUpgrades(@RequestBody OwnCard updateOwnCard) {
+    return OwnCardService.redistributeUpgrades(updateOwnCard);
+  }
 }

--- a/CDBackend/demo/src/main/java/com/example/accessingdatamysql/dao/OwnCardDao.java
+++ b/CDBackend/demo/src/main/java/com/example/accessingdatamysql/dao/OwnCardDao.java
@@ -18,6 +18,8 @@ public interface OwnCardDao {
         // 更新一个用户拥有某张卡牌的所有信息
         OwnCard updateOwnCard(OwnCard updateOwnCard);
 
+        OwnCard redistributeUpgrades(OwnCard updateOwnCard);
+
         // 用户拥有的某张卡牌升级
         OwnCard cardLevelUp(Integer userId, Integer cardId);
 

--- a/CDBackend/demo/src/main/java/com/example/accessingdatamysql/daoimpl/OwnCardDaoImpl.java
+++ b/CDBackend/demo/src/main/java/com/example/accessingdatamysql/daoimpl/OwnCardDaoImpl.java
@@ -45,6 +45,49 @@ public class OwnCardDaoImpl implements OwnCardDao {
         return null;
     }
 
+    @Override
+    public OwnCard redistributeUpgrades(OwnCard updateOwnCard) {
+        final Optional<OwnCard> optOwnCard = OwnCardRepository.findById(updateOwnCard.getOwnCardId());
+        if (optOwnCard.isPresent()) {
+            final OwnCard originalOwnCard = optOwnCard.get();
+            int leftUpgPt = originalOwnCard.getLeftPoints();
+            Integer newEnhancedPt;
+            if((newEnhancedPt = updateOwnCard.getEnhanceAttack()) != null) {
+                leftUpgPt -= (newEnhancedPt - originalOwnCard.getEnhanceAttack());
+                originalOwnCard.setEnhanceAttack(newEnhancedPt);
+            }
+            if((newEnhancedPt = updateOwnCard.getEnhanceAttackRange()) != null) {
+                leftUpgPt -= (newEnhancedPt - originalOwnCard.getEnhanceAttackRange());
+                originalOwnCard.setEnhanceAttackRange(newEnhancedPt);
+            }
+            if((newEnhancedPt = updateOwnCard.getEnhanceCD()) != null) {
+                leftUpgPt -= (newEnhancedPt - originalOwnCard.getEnhanceCD());
+                originalOwnCard.setEnhanceCD(newEnhancedPt);
+            }
+            if((newEnhancedPt = updateOwnCard.getEnhanceDefense()) != null) {
+                leftUpgPt -= (newEnhancedPt - originalOwnCard.getEnhanceDefense());
+                originalOwnCard.setEnhanceDefense(newEnhancedPt);
+            }
+            if((newEnhancedPt = updateOwnCard.getEnhanceHP()) != null) {
+                leftUpgPt -= (newEnhancedPt - originalOwnCard.getEnhanceHP());
+                originalOwnCard.setEnhanceHP(newEnhancedPt);
+            }
+            if((newEnhancedPt = updateOwnCard.getEnhanceSpeed()) != null) {
+                leftUpgPt -= (newEnhancedPt - originalOwnCard.getEnhanceSpeed());
+                originalOwnCard.setEnhanceSpeed(newEnhancedPt);
+            }
+            if(leftUpgPt < 0) {
+                System.out.println("OwnCardDaoImpl::redistributeUpgrades: Illegal redistribute! Left point: " + leftUpgPt);
+                return null;
+            }
+            originalOwnCard.setLeftPoints(leftUpgPt);
+            OwnCardRepository.updateOwnCardStatus(updateOwnCard, updateOwnCard.getOwnCardId());
+            return updateOwnCard;
+        }
+        System.out.println("OwnCardDaoImpl::redistributeUpgrades: Not found id: " + updateOwnCard.getOwnCardId());
+        return null;
+    }
+
     // 用户拥有的某张卡牌升级
     public OwnCard cardLevelUp(Integer userId, Integer cardId) {
         Optional<OwnCard> optOwnCard = OwnCardRepository.findOwnCardByUserIdEqualsAndCardIdEquals(userId, cardId);

--- a/CDBackend/demo/src/main/java/com/example/accessingdatamysql/service/OwnCardService.java
+++ b/CDBackend/demo/src/main/java/com/example/accessingdatamysql/service/OwnCardService.java
@@ -16,6 +16,8 @@ public interface OwnCardService {
         // 更新一个用户拥有某张卡牌的所有信息
         OwnCard updateOwnCard(OwnCard updateOwnCard);
 
+        OwnCard redistributeUpgrades(OwnCard updateOwnCard);
+
         // 用户拥有的某张卡牌升级
         // OwnCard cardLevelUp(Integer userId, Integer cardId);
 

--- a/CDBackend/demo/src/main/java/com/example/accessingdatamysql/serviceimpl/OwnCardServiceImpl.java
+++ b/CDBackend/demo/src/main/java/com/example/accessingdatamysql/serviceimpl/OwnCardServiceImpl.java
@@ -64,6 +64,11 @@ public class OwnCardServiceImpl implements OwnCardService {
         return OwnCardDao.updateOwnCard(updateOwnCard);
     }
 
+    @Override
+    public OwnCard redistributeUpgrades(OwnCard updateOwnCard) {
+        return OwnCardDao.redistributeUpgrades(updateOwnCard);
+    }
+
     // 自动判断增加exp是是否需要升级
     @Override
     public OwnCard addExp(final Integer userId, final Integer cardId, final Integer exp) {


### PR DESCRIPTION
简单介绍一下：
·实际逻辑写在DaoImpl
·客户端只提交该OwnCardId与有变动的强化项目
·剩余强化点数变动由后端执行，如检测分配异常则撤销更改，但这个过程不被前端看到。前端为了速度和数据传输量减低，会直接认为更改成功并编辑缓冲。